### PR TITLE
Temporarily remove renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
   "statusCheckVerify": true,
   "ignoreDeps": [


### PR DESCRIPTION
Going to let some package dependency upgrade PRs generate, then go back to the early Monday schedule