### PR TITLE
DISCO-1371: Only save course runs that changed

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -8,8 +8,8 @@ import ActionButton from '../ActionButton';
 import ButtonToolbar from '../ButtonToolbar';
 import { courseSubmittingInfo } from '../../data/actions/courseSubmitInfo';
 import FieldLabel from '../FieldLabel';
-import { localTimeZone, formatDate, isSafari, getDateWithDashes, getDateWithSlashes,
-  isNonExemptChanged, isPristine } from '../../utils/index';
+import { courseRunIsArchived, localTimeZone, formatDate, isSafari, getDateWithDashes,
+  getDateWithSlashes, isNonExemptChanged, isPristine } from '../../utils/index';
 import Pill from '../Pill';
 import RenderInputTextField from '../RenderInputTextField';
 import RenderSelectField from '../RenderSelectField';
@@ -25,8 +25,7 @@ import {
 import { dateEditHelp, pacingEditHelp, publishDateHelp } from '../../helpText';
 import RichEditor from '../RichEditor';
 
-const determineStatus = courseRun => (courseRun.status === 'unpublished' && moment().isAfter(courseRun.end) ?
-  'archived' : courseRun.status);
+const determineStatus = run => (courseRunIsArchived(run) ? 'archived' : run.status);
 
 const formatCourseRunTitle = (courseRun) => {
   if (courseRun) {

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -16,13 +16,58 @@ jest.mock('@tinymce/tinymce-react');
 const mockStore = configureStore();
 
 describe('EditCoursePage', () => {
+  const defaultPrice = '77.00';
+  const defaultEnd = '2019-08-14T00:00:00Z';
+
   const courseInfo = {
     data: {
       additional_information: '',
+      course_runs: [
+        {
+          key: 'edX101+DemoX+T2',
+          start: '2019-05-14T00:00:00Z',
+          end: defaultEnd,
+          expected_program_type: 'micromasters',
+          expected_program_name: 'Test Program Name',
+          go_live_date: '2019-05-06T00:00:00Z',
+          min_effort: 10,
+          max_effort: 123,
+          pacing_type: 'instructor_paced',
+          content_language: 'en-us',
+          transcript_languages: ['en-us'],
+          weeks_to_complete: 100,
+          staff: [],
+          status: UNPUBLISHED,
+          draft: undefined,
+          marketing_url: null,
+          has_ofac_restrictions: false,
+          ofac_comment: '',
+        },
+        {
+          key: 'edX101+DemoX+T1',
+          start: '2019-05-14T00:00:00Z',
+          end: defaultEnd,
+          expected_program_type: null,
+          expected_program_name: '',
+          go_live_date: '2019-05-06T00:00:00Z',
+          min_effort: 10,
+          max_effort: 123,
+          pacing_type: 'instructor_paced',
+          content_language: 'en-us',
+          transcript_languages: ['en-us'],
+          weeks_to_complete: 100,
+          staff: [],
+          status: PUBLISHED,
+          draft: undefined,
+          marketing_url: null,
+          has_ofac_restrictions: false,
+          ofac_comment: '',
+        },
+      ],
       entitlements: [
         {
           mode: 'verified',
-          price: '77.00',
+          price: defaultPrice,
           currency: 'USD',
           sku: '000000D',
           expires: null,
@@ -303,21 +348,23 @@ describe('EditCoursePage', () => {
   describe('EditCoursePage submission handling', () => {
     const publishedCourseRun = {
       key: 'edX101+DemoX+T1',
-      status: PUBLISHED,
-      content_language: 'en-us',
-      draft: undefined,
-      end: '2019-08-14T00:00:00Z',
+      start: '2019-05-14T00:00:00Z',
+      end: defaultEnd,
       expected_program_type: null,
       expected_program_name: '',
       go_live_date: '2019-05-06T00:00:00Z',
-      marketing_url: null,
-      max_effort: 123,
-      min_effort: 10,
+      min_effort: '10',
+      max_effort: '123',
       pacing_type: 'instructor_paced',
-      staff: [],
-      start: '2019-05-14T00:00:00Z',
+      content_language: 'en-us',
       transcript_languages: ['en-us'],
-      weeks_to_complete: 100,
+      weeks_to_complete: '100',
+      staff: [],
+      status: PUBLISHED,
+      draft: undefined,
+      marketing_url: null,
+      has_ofac_restrictions: false,
+      ofac_comment: '',
     };
 
     const unpublishedCourseRun = Object.assign(
@@ -342,13 +389,14 @@ describe('EditCoursePage', () => {
       mode: 'verified',
       outcome: '<p>Stuff</p>',
       prerequisites_raw: '',
-      price: '200.00',
+      price: defaultPrice,
       short_description: '<p>Short</p>',
       subjectPrimary: 'basket-weaving',
       subjectSecondary: undefined,
       subjectTertiary: undefined,
       syllabus_raw: null,
       title: 'demo4004',
+      url_slug: 'demo4004',
       videoSrc: null,
       editable: true,
     };
@@ -356,7 +404,7 @@ describe('EditCoursePage', () => {
     const expectedSendCourse = {
       additional_information: '<p>Stuff</p>',
       draft: true,
-      entitlements: [{ mode: 'verified', price: '200.00', sku: '000000D' }],
+      entitlements: [{ mode: 'verified', price: defaultPrice, sku: '000000D' }],
       faq: '<p>Help?</p>',
       full_description: '<p>Long</p>',
       image: 'http://image.jpg',
@@ -367,6 +415,7 @@ describe('EditCoursePage', () => {
       short_description: '<p>Short</p>',
       subjects: ['basket-weaving'],
       title: 'demo4004',
+      url_slug: 'demo4004',
       uuid: '00000000-0000-0000-0000-000000000000',
       video: { src: null },
     };
@@ -379,14 +428,13 @@ describe('EditCoursePage', () => {
         expected_program_name: 'Test Program Name',
         go_live_date: '2019-05-06T00:00:00Z',
         key: 'edX101+DemoX+T2',
-        max_effort: 123,
-        min_effort: 10,
+        max_effort: '123',
+        min_effort: '10',
         rerun: null,
         staff: [],
-        length: undefined,
-        status: 'unpublished',
+        status: UNPUBLISHED,
         transcript_languages: ['en-us'],
-        weeks_to_complete: 100,
+        weeks_to_complete: '100',
       },
       {
         content_language: 'en-us',
@@ -395,14 +443,13 @@ describe('EditCoursePage', () => {
         expected_program_name: '',
         go_live_date: '2019-05-06T00:00:00Z',
         key: 'edX101+DemoX+T1',
-        max_effort: 123,
-        min_effort: 10,
+        max_effort: '123',
+        min_effort: '10',
         rerun: null,
         staff: [],
-        length: undefined,
-        status: 'published',
+        status: PUBLISHED,
         transcript_languages: ['en-us'],
-        weeks_to_complete: 100,
+        weeks_to_complete: '100',
       },
     ];
 
@@ -410,9 +457,15 @@ describe('EditCoursePage', () => {
 
     beforeEach(() => {
       mockHandleCourseSubmit.mockClear();
+
+      courseData.price = defaultPrice;
+      courseData.course_runs[0].end = defaultEnd;
+      courseData.course_runs[0].status = UNPUBLISHED;
+
       expectedSendCourseRuns[0].draft = true;
       expectedSendCourseRuns[1].draft = true;
       expectedSendCourse.draft = true;
+      expectedSendCourse.entitlements[0].price = defaultPrice;
     });
 
     it('sets state correctly and does not show modal with no target run', () => {
@@ -420,7 +473,6 @@ describe('EditCoursePage', () => {
         courseInfo={courseInfo}
       />);
 
-      // const component = mount(EditCoursePageWrapper());
       component.setState({
         submitConfirmVisible: false,
       });
@@ -547,7 +599,7 @@ describe('EditCoursePage', () => {
       expect(createAlert.props().message).toEqual(createMessage);
     });
 
-    it('handleCourseSubmit properly prepares course data for Save Edits case', () => {
+    it('handleCourseSubmit properly prepares course data for Save Edits case with no changes', () => {
       const mockEditCourse = jest.fn();
       const props = {
         editCourse: mockEditCourse,
@@ -565,12 +617,66 @@ describe('EditCoursePage', () => {
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
+        [],
+        false,
+      );
+    });
+
+    it('handleCourseSubmit properly prepares course data for Save Edits case with course changes (no archived run)', () => {
+      const mockEditCourse = jest.fn();
+      const props = {
+        editCourse: mockEditCourse,
+      };
+      const component = shallow(<EditCoursePage
+        {...props}
+        courseInfo={courseInfo}
+      />);
+
+      component.setState({
+        submitConfirmVisible: true,
+      });
+      component.update();
+
+      courseData.price = '500.00';
+      courseData.course_runs[0].end = '5000-08-12T12:34:56Z';
+
+      expectedSendCourse.entitlements[0].price = '500.00';
+
+      component.instance().handleCourseSubmit(courseData);
+      expect(mockEditCourse).toHaveBeenCalledWith(
+        expectedSendCourse,
         expectedSendCourseRuns,
         false,
       );
     });
 
-    it('handleCourseSubmit properly prepares course data for Published Submit case', () => {
+    it('handleCourseSubmit properly prepares course data for Save Edits case with course changes (archived run)', () => {
+      const mockEditCourse = jest.fn();
+      const props = {
+        editCourse: mockEditCourse,
+      };
+      const component = shallow(<EditCoursePage
+        {...props}
+        courseInfo={courseInfo}
+      />);
+
+      component.setState({
+        submitConfirmVisible: true,
+      });
+      component.update();
+
+      courseData.price = '500.00';
+      expectedSendCourse.entitlements[0].price = '500.00';
+
+      component.instance().handleCourseSubmit(courseData);
+      expect(mockEditCourse).toHaveBeenCalledWith(
+        expectedSendCourse,
+        [expectedSendCourseRuns[1]],
+        false,
+      );
+    });
+
+    it('handleCourseSubmit properly prepares course data for Published run Submit case', () => {
       const mockEditCourse = jest.fn();
       const props = {
         editCourse: mockEditCourse,
@@ -594,12 +700,12 @@ describe('EditCoursePage', () => {
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
-        expectedSendCourseRuns,
+        [expectedSendCourseRuns[1]],
         true,
       );
     });
 
-    it('handleCourseSubmit properly prepares course data for Unpublished Submits case', () => {
+    it('handleCourseSubmit properly prepares course data for Unpublished run Submit case', () => {
       const mockEditCourse = jest.fn();
       const props = {
         editCourse: mockEditCourse,
@@ -622,8 +728,39 @@ describe('EditCoursePage', () => {
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
-        expectedSendCourseRuns,
+        [expectedSendCourseRuns[0]],
         true,
+      );
+    });
+
+    it('handleCourseSubmit properly prepares course data for Save Edits case with run in review', () => {
+      const mockEditCourse = jest.fn();
+      const props = {
+        editCourse: mockEditCourse,
+      };
+      const component = shallow(<EditCoursePage
+        {...props}
+        courseInfo={courseInfo}
+      />);
+
+      component.setState({
+        submitConfirmVisible: true,
+      });
+      component.update();
+
+      // Course changed so it should send saves for all non-archived runs, but this run is
+      // in review so it won't be sent.
+      courseData.price = '500.00';
+      courseData.course_runs[0].end = '5000-08-12T12:34:56Z';
+      courseData.course_runs[0].status = REVIEW_BY_INTERNAL;
+
+      expectedSendCourse.entitlements[0].price = '500.00';
+
+      component.instance().handleCourseSubmit(courseData);
+      expect(mockEditCourse).toHaveBeenCalledWith(
+        expectedSendCourse,
+        [expectedSendCourseRuns[1]],
+        false,
       );
     });
 

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -1349,6 +1349,52 @@ ShallowWrapper {
       Object {
         "data": Object {
           "additional_information": "",
+          "course_runs": Array [
+            Object {
+              "content_language": "en-us",
+              "draft": undefined,
+              "end": "2019-08-14T00:00:00Z",
+              "expected_program_name": "Test Program Name",
+              "expected_program_type": "micromasters",
+              "go_live_date": "2019-05-06T00:00:00Z",
+              "has_ofac_restrictions": false,
+              "key": "edX101+DemoX+T2",
+              "marketing_url": null,
+              "max_effort": 123,
+              "min_effort": 10,
+              "ofac_comment": "",
+              "pacing_type": "instructor_paced",
+              "staff": Array [],
+              "start": "2019-05-14T00:00:00Z",
+              "status": "unpublished",
+              "transcript_languages": Array [
+                "en-us",
+              ],
+              "weeks_to_complete": 100,
+            },
+            Object {
+              "content_language": "en-us",
+              "draft": undefined,
+              "end": "2019-08-14T00:00:00Z",
+              "expected_program_name": "",
+              "expected_program_type": null,
+              "go_live_date": "2019-05-06T00:00:00Z",
+              "has_ofac_restrictions": false,
+              "key": "edX101+DemoX+T1",
+              "marketing_url": null,
+              "max_effort": 123,
+              "min_effort": 10,
+              "ofac_comment": "",
+              "pacing_type": "instructor_paced",
+              "staff": Array [],
+              "start": "2019-05-14T00:00:00Z",
+              "status": "published",
+              "transcript_languages": Array [
+                "en-us",
+              ],
+              "weeks_to_complete": 100,
+            },
+          ],
           "entitlements": Array [
             Object {
               "currency": "USD",
@@ -1528,10 +1574,57 @@ ShallowWrapper {
                 "data": Array [],
               }
             }
+            courseInReview={false}
             courseInfo={
               Object {
                 "data": Object {
                   "additional_information": "",
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                  ],
                   "entitlements": Array [
                     Object {
                       "currency": "USD",
@@ -1591,7 +1684,59 @@ ShallowWrapper {
             }
             courseOptions={Object {}}
             courseRunOptions={Object {}}
-            courseStatuses={Array []}
+            courseRuns={
+              Array [
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "Test Program Name",
+                  "expected_program_type": "micromasters",
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T2",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "unpublished",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "",
+                  "expected_program_type": null,
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T1",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "published",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+              ]
+            }
+            courseStatuses={
+              Array [
+                "published",
+              ]
+            }
             courseSubmitInfo={Object {}}
             editCourse={[Function]}
             entitlement={
@@ -1615,7 +1760,52 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "",
-                "course_runs": undefined,
+                "course_runs": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
                 "faq": "",
                 "full_description": "<p>long desc</p>",
                 "imageSrc": "http://path/to/image/woo.small",
@@ -1747,10 +1937,57 @@ ShallowWrapper {
                   "data": Array [],
                 }
               }
+              courseInReview={false}
               courseInfo={
                 Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -1810,7 +2047,59 @@ ShallowWrapper {
               }
               courseOptions={Object {}}
               courseRunOptions={Object {}}
-              courseStatuses={Array []}
+              courseRuns={
+                Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ]
+              }
+              courseStatuses={
+                Array [
+                  "published",
+                ]
+              }
               courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={
@@ -1834,7 +2123,52 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -1942,10 +2276,56 @@ ShallowWrapper {
               "courseEditors": Object {
                 "data": Array [],
               },
-              "courseInReview": undefined,
+              "courseInReview": false,
               "courseInfo": Object {
                 "data": Object {
                   "additional_information": "",
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                  ],
                   "entitlements": Array [
                     Object {
                       "currency": "USD",
@@ -2004,8 +2384,55 @@ ShallowWrapper {
               },
               "courseOptions": Object {},
               "courseRunOptions": Object {},
-              "courseRuns": undefined,
-              "courseStatuses": Array [],
+              "courseRuns": Array [
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "Test Program Name",
+                  "expected_program_type": "micromasters",
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T2",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "unpublished",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "",
+                  "expected_program_type": null,
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T1",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "published",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+              ],
+              "courseStatuses": Array [
+                "published",
+              ],
               "courseSubmitInfo": Object {},
               "currentFormValues": undefined,
               "editCourse": [Function],
@@ -2028,7 +2455,52 @@ ShallowWrapper {
               "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
               "initialValues": Object {
                 "additional_information": "",
-                "course_runs": undefined,
+                "course_runs": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
                 "faq": "",
                 "full_description": "<p>long desc</p>",
                 "imageSrc": "http://path/to/image/woo.small",
@@ -2163,10 +2635,57 @@ ShallowWrapper {
                   "data": Array [],
                 }
               }
+              courseInReview={false}
               courseInfo={
                 Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -2226,7 +2745,59 @@ ShallowWrapper {
               }
               courseOptions={Object {}}
               courseRunOptions={Object {}}
-              courseStatuses={Array []}
+              courseRuns={
+                Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ]
+              }
+              courseStatuses={
+                Array [
+                  "published",
+                ]
+              }
               courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={
@@ -2250,7 +2821,52 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -2382,10 +2998,57 @@ ShallowWrapper {
                     "data": Array [],
                   }
                 }
+                courseInReview={false}
                 courseInfo={
                   Object {
                     "data": Object {
                       "additional_information": "",
+                      "course_runs": Array [
+                        Object {
+                          "content_language": "en-us",
+                          "draft": undefined,
+                          "end": "2019-08-14T00:00:00Z",
+                          "expected_program_name": "Test Program Name",
+                          "expected_program_type": "micromasters",
+                          "go_live_date": "2019-05-06T00:00:00Z",
+                          "has_ofac_restrictions": false,
+                          "key": "edX101+DemoX+T2",
+                          "marketing_url": null,
+                          "max_effort": 123,
+                          "min_effort": 10,
+                          "ofac_comment": "",
+                          "pacing_type": "instructor_paced",
+                          "staff": Array [],
+                          "start": "2019-05-14T00:00:00Z",
+                          "status": "unpublished",
+                          "transcript_languages": Array [
+                            "en-us",
+                          ],
+                          "weeks_to_complete": 100,
+                        },
+                        Object {
+                          "content_language": "en-us",
+                          "draft": undefined,
+                          "end": "2019-08-14T00:00:00Z",
+                          "expected_program_name": "",
+                          "expected_program_type": null,
+                          "go_live_date": "2019-05-06T00:00:00Z",
+                          "has_ofac_restrictions": false,
+                          "key": "edX101+DemoX+T1",
+                          "marketing_url": null,
+                          "max_effort": 123,
+                          "min_effort": 10,
+                          "ofac_comment": "",
+                          "pacing_type": "instructor_paced",
+                          "staff": Array [],
+                          "start": "2019-05-14T00:00:00Z",
+                          "status": "published",
+                          "transcript_languages": Array [
+                            "en-us",
+                          ],
+                          "weeks_to_complete": 100,
+                        },
+                      ],
                       "entitlements": Array [
                         Object {
                           "currency": "USD",
@@ -2445,7 +3108,59 @@ ShallowWrapper {
                 }
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
-                courseStatuses={Array []}
+                courseRuns={
+                  Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ]
+                }
+                courseStatuses={
+                  Array [
+                    "published",
+                  ]
+                }
                 courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={
@@ -2469,7 +3184,52 @@ ShallowWrapper {
                 initialValues={
                   Object {
                     "additional_information": "",
-                    "course_runs": undefined,
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": "123",
+                        "min_effort": "10",
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": "100",
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": "123",
+                        "min_effort": "10",
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": "100",
+                      },
+                    ],
                     "faq": "",
                     "full_description": "<p>long desc</p>",
                     "imageSrc": "http://path/to/image/woo.small",
@@ -2577,10 +3337,56 @@ ShallowWrapper {
                 "courseEditors": Object {
                   "data": Array [],
                 },
-                "courseInReview": undefined,
+                "courseInReview": false,
                 "courseInfo": Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -2639,8 +3445,55 @@ ShallowWrapper {
                 },
                 "courseOptions": Object {},
                 "courseRunOptions": Object {},
-                "courseRuns": undefined,
-                "courseStatuses": Array [],
+                "courseRuns": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
+                "courseStatuses": Array [
+                  "published",
+                ],
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
@@ -2663,7 +3516,52 @@ ShallowWrapper {
                 "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                 "initialValues": Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -2759,6 +3657,52 @@ ShallowWrapper {
       Object {
         "data": Object {
           "additional_information": "",
+          "course_runs": Array [
+            Object {
+              "content_language": "en-us",
+              "draft": undefined,
+              "end": "2019-08-14T00:00:00Z",
+              "expected_program_name": "Test Program Name",
+              "expected_program_type": "micromasters",
+              "go_live_date": "2019-05-06T00:00:00Z",
+              "has_ofac_restrictions": false,
+              "key": "edX101+DemoX+T2",
+              "marketing_url": null,
+              "max_effort": 123,
+              "min_effort": 10,
+              "ofac_comment": "",
+              "pacing_type": "instructor_paced",
+              "staff": Array [],
+              "start": "2019-05-14T00:00:00Z",
+              "status": "unpublished",
+              "transcript_languages": Array [
+                "en-us",
+              ],
+              "weeks_to_complete": 100,
+            },
+            Object {
+              "content_language": "en-us",
+              "draft": undefined,
+              "end": "2019-08-14T00:00:00Z",
+              "expected_program_name": "",
+              "expected_program_type": null,
+              "go_live_date": "2019-05-06T00:00:00Z",
+              "has_ofac_restrictions": false,
+              "key": "edX101+DemoX+T1",
+              "marketing_url": null,
+              "max_effort": 123,
+              "min_effort": 10,
+              "ofac_comment": "",
+              "pacing_type": "instructor_paced",
+              "staff": Array [],
+              "start": "2019-05-14T00:00:00Z",
+              "status": "published",
+              "transcript_languages": Array [
+                "en-us",
+              ],
+              "weeks_to_complete": 100,
+            },
+          ],
           "entitlements": Array [
             Object {
               "currency": "USD",
@@ -2987,10 +3931,57 @@ ShallowWrapper {
                 "data": Array [],
               }
             }
+            courseInReview={false}
             courseInfo={
               Object {
                 "data": Object {
                   "additional_information": "",
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                  ],
                   "entitlements": Array [
                     Object {
                       "currency": "USD",
@@ -3099,7 +4090,59 @@ ShallowWrapper {
               }
             }
             courseRunOptions={Object {}}
-            courseStatuses={Array []}
+            courseRuns={
+              Array [
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "Test Program Name",
+                  "expected_program_type": "micromasters",
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T2",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "unpublished",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "",
+                  "expected_program_type": null,
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T1",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "published",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+              ]
+            }
+            courseStatuses={
+              Array [
+                "published",
+              ]
+            }
             courseSubmitInfo={Object {}}
             editCourse={[Function]}
             entitlement={
@@ -3123,7 +4166,52 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "",
-                "course_runs": undefined,
+                "course_runs": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
                 "faq": "",
                 "full_description": "<p>long desc</p>",
                 "imageSrc": "http://path/to/image/woo.small",
@@ -3255,10 +4343,57 @@ ShallowWrapper {
                   "data": Array [],
                 }
               }
+              courseInReview={false}
               courseInfo={
                 Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -3367,7 +4502,59 @@ ShallowWrapper {
                 }
               }
               courseRunOptions={Object {}}
-              courseStatuses={Array []}
+              courseRuns={
+                Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ]
+              }
+              courseStatuses={
+                Array [
+                  "published",
+                ]
+              }
               courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={
@@ -3391,7 +4578,52 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -3499,10 +4731,56 @@ ShallowWrapper {
               "courseEditors": Object {
                 "data": Array [],
               },
-              "courseInReview": undefined,
+              "courseInReview": false,
               "courseInfo": Object {
                 "data": Object {
                   "additional_information": "",
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                  ],
                   "entitlements": Array [
                     Object {
                       "currency": "USD",
@@ -3608,8 +4886,55 @@ ShallowWrapper {
                 "isFetching": false,
               },
               "courseRunOptions": Object {},
-              "courseRuns": undefined,
-              "courseStatuses": Array [],
+              "courseRuns": Array [
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "Test Program Name",
+                  "expected_program_type": "micromasters",
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T2",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "unpublished",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "",
+                  "expected_program_type": null,
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T1",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "published",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+              ],
+              "courseStatuses": Array [
+                "published",
+              ],
               "courseSubmitInfo": Object {},
               "currentFormValues": undefined,
               "editCourse": [Function],
@@ -3632,7 +4957,52 @@ ShallowWrapper {
               "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
               "initialValues": Object {
                 "additional_information": "",
-                "course_runs": undefined,
+                "course_runs": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
                 "faq": "",
                 "full_description": "<p>long desc</p>",
                 "imageSrc": "http://path/to/image/woo.small",
@@ -3767,10 +5137,57 @@ ShallowWrapper {
                   "data": Array [],
                 }
               }
+              courseInReview={false}
               courseInfo={
                 Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -3879,7 +5296,59 @@ ShallowWrapper {
                 }
               }
               courseRunOptions={Object {}}
-              courseStatuses={Array []}
+              courseRuns={
+                Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ]
+              }
+              courseStatuses={
+                Array [
+                  "published",
+                ]
+              }
               courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={
@@ -3903,7 +5372,52 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -4035,10 +5549,57 @@ ShallowWrapper {
                     "data": Array [],
                   }
                 }
+                courseInReview={false}
                 courseInfo={
                   Object {
                     "data": Object {
                       "additional_information": "",
+                      "course_runs": Array [
+                        Object {
+                          "content_language": "en-us",
+                          "draft": undefined,
+                          "end": "2019-08-14T00:00:00Z",
+                          "expected_program_name": "Test Program Name",
+                          "expected_program_type": "micromasters",
+                          "go_live_date": "2019-05-06T00:00:00Z",
+                          "has_ofac_restrictions": false,
+                          "key": "edX101+DemoX+T2",
+                          "marketing_url": null,
+                          "max_effort": 123,
+                          "min_effort": 10,
+                          "ofac_comment": "",
+                          "pacing_type": "instructor_paced",
+                          "staff": Array [],
+                          "start": "2019-05-14T00:00:00Z",
+                          "status": "unpublished",
+                          "transcript_languages": Array [
+                            "en-us",
+                          ],
+                          "weeks_to_complete": 100,
+                        },
+                        Object {
+                          "content_language": "en-us",
+                          "draft": undefined,
+                          "end": "2019-08-14T00:00:00Z",
+                          "expected_program_name": "",
+                          "expected_program_type": null,
+                          "go_live_date": "2019-05-06T00:00:00Z",
+                          "has_ofac_restrictions": false,
+                          "key": "edX101+DemoX+T1",
+                          "marketing_url": null,
+                          "max_effort": 123,
+                          "min_effort": 10,
+                          "ofac_comment": "",
+                          "pacing_type": "instructor_paced",
+                          "staff": Array [],
+                          "start": "2019-05-14T00:00:00Z",
+                          "status": "published",
+                          "transcript_languages": Array [
+                            "en-us",
+                          ],
+                          "weeks_to_complete": 100,
+                        },
+                      ],
                       "entitlements": Array [
                         Object {
                           "currency": "USD",
@@ -4147,7 +5708,59 @@ ShallowWrapper {
                   }
                 }
                 courseRunOptions={Object {}}
-                courseStatuses={Array []}
+                courseRuns={
+                  Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ]
+                }
+                courseStatuses={
+                  Array [
+                    "published",
+                  ]
+                }
                 courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={
@@ -4171,7 +5784,52 @@ ShallowWrapper {
                 initialValues={
                   Object {
                     "additional_information": "",
-                    "course_runs": undefined,
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": "123",
+                        "min_effort": "10",
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": "100",
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": "123",
+                        "min_effort": "10",
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": "100",
+                      },
+                    ],
                     "faq": "",
                     "full_description": "<p>long desc</p>",
                     "imageSrc": "http://path/to/image/woo.small",
@@ -4279,10 +5937,56 @@ ShallowWrapper {
                 "courseEditors": Object {
                   "data": Array [],
                 },
-                "courseInReview": undefined,
+                "courseInReview": false,
                 "courseInfo": Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -4388,8 +6092,55 @@ ShallowWrapper {
                   "isFetching": false,
                 },
                 "courseRunOptions": Object {},
-                "courseRuns": undefined,
-                "courseStatuses": Array [],
+                "courseRuns": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
+                "courseStatuses": Array [
+                  "published",
+                ],
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
@@ -4412,7 +6163,52 @@ ShallowWrapper {
                 "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                 "initialValues": Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -5596,6 +7392,52 @@ ShallowWrapper {
       Object {
         "data": Object {
           "additional_information": "",
+          "course_runs": Array [
+            Object {
+              "content_language": "en-us",
+              "draft": undefined,
+              "end": "2019-08-14T00:00:00Z",
+              "expected_program_name": "Test Program Name",
+              "expected_program_type": "micromasters",
+              "go_live_date": "2019-05-06T00:00:00Z",
+              "has_ofac_restrictions": false,
+              "key": "edX101+DemoX+T2",
+              "marketing_url": null,
+              "max_effort": 123,
+              "min_effort": 10,
+              "ofac_comment": "",
+              "pacing_type": "instructor_paced",
+              "staff": Array [],
+              "start": "2019-05-14T00:00:00Z",
+              "status": "unpublished",
+              "transcript_languages": Array [
+                "en-us",
+              ],
+              "weeks_to_complete": 100,
+            },
+            Object {
+              "content_language": "en-us",
+              "draft": undefined,
+              "end": "2019-08-14T00:00:00Z",
+              "expected_program_name": "",
+              "expected_program_type": null,
+              "go_live_date": "2019-05-06T00:00:00Z",
+              "has_ofac_restrictions": false,
+              "key": "edX101+DemoX+T1",
+              "marketing_url": null,
+              "max_effort": 123,
+              "min_effort": 10,
+              "ofac_comment": "",
+              "pacing_type": "instructor_paced",
+              "staff": Array [],
+              "start": "2019-05-14T00:00:00Z",
+              "status": "published",
+              "transcript_languages": Array [
+                "en-us",
+              ],
+              "weeks_to_complete": 100,
+            },
+          ],
           "entitlements": Array [
             Object {
               "currency": "USD",
@@ -5892,10 +7734,57 @@ ShallowWrapper {
                 "data": Array [],
               }
             }
+            courseInReview={false}
             courseInfo={
               Object {
                 "data": Object {
                   "additional_information": "",
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                  ],
                   "entitlements": Array [
                     Object {
                       "currency": "USD",
@@ -6072,7 +7961,59 @@ ShallowWrapper {
                 "isFetching": false,
               }
             }
-            courseStatuses={Array []}
+            courseRuns={
+              Array [
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "Test Program Name",
+                  "expected_program_type": "micromasters",
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T2",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "unpublished",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "",
+                  "expected_program_type": null,
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T1",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "published",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+              ]
+            }
+            courseStatuses={
+              Array [
+                "published",
+              ]
+            }
             courseSubmitInfo={Object {}}
             editCourse={[Function]}
             entitlement={
@@ -6096,7 +8037,52 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "",
-                "course_runs": undefined,
+                "course_runs": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
                 "faq": "",
                 "full_description": "<p>long desc</p>",
                 "imageSrc": "http://path/to/image/woo.small",
@@ -6228,10 +8214,57 @@ ShallowWrapper {
                   "data": Array [],
                 }
               }
+              courseInReview={false}
               courseInfo={
                 Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -6408,7 +8441,59 @@ ShallowWrapper {
                   "isFetching": false,
                 }
               }
-              courseStatuses={Array []}
+              courseRuns={
+                Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ]
+              }
+              courseStatuses={
+                Array [
+                  "published",
+                ]
+              }
               courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={
@@ -6432,7 +8517,52 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -6540,10 +8670,56 @@ ShallowWrapper {
               "courseEditors": Object {
                 "data": Array [],
               },
-              "courseInReview": undefined,
+              "courseInReview": false,
               "courseInfo": Object {
                 "data": Object {
                   "additional_information": "",
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": 123,
+                      "min_effort": 10,
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": 100,
+                    },
+                  ],
                   "entitlements": Array [
                     Object {
                       "currency": "USD",
@@ -6715,8 +8891,55 @@ ShallowWrapper {
                 "error": null,
                 "isFetching": false,
               },
-              "courseRuns": undefined,
-              "courseStatuses": Array [],
+              "courseRuns": Array [
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "Test Program Name",
+                  "expected_program_type": "micromasters",
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T2",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "unpublished",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+                Object {
+                  "content_language": "en-us",
+                  "draft": undefined,
+                  "end": "2019-08-14T00:00:00Z",
+                  "expected_program_name": "",
+                  "expected_program_type": null,
+                  "go_live_date": "2019-05-06T00:00:00Z",
+                  "has_ofac_restrictions": false,
+                  "key": "edX101+DemoX+T1",
+                  "marketing_url": null,
+                  "max_effort": "123",
+                  "min_effort": "10",
+                  "ofac_comment": "",
+                  "pacing_type": "instructor_paced",
+                  "staff": Array [],
+                  "start": "2019-05-14T00:00:00Z",
+                  "status": "published",
+                  "transcript_languages": Array [
+                    "en-us",
+                  ],
+                  "weeks_to_complete": "100",
+                },
+              ],
+              "courseStatuses": Array [
+                "published",
+              ],
               "courseSubmitInfo": Object {},
               "currentFormValues": undefined,
               "editCourse": [Function],
@@ -6739,7 +8962,52 @@ ShallowWrapper {
               "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
               "initialValues": Object {
                 "additional_information": "",
-                "course_runs": undefined,
+                "course_runs": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
                 "faq": "",
                 "full_description": "<p>long desc</p>",
                 "imageSrc": "http://path/to/image/woo.small",
@@ -6874,10 +9142,57 @@ ShallowWrapper {
                   "data": Array [],
                 }
               }
+              courseInReview={false}
               courseInfo={
                 Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -7054,7 +9369,59 @@ ShallowWrapper {
                   "isFetching": false,
                 }
               }
-              courseStatuses={Array []}
+              courseRuns={
+                Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ]
+              }
+              courseStatuses={
+                Array [
+                  "published",
+                ]
+              }
               courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={
@@ -7078,7 +9445,52 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",
@@ -7210,10 +9622,57 @@ ShallowWrapper {
                     "data": Array [],
                   }
                 }
+                courseInReview={false}
                 courseInfo={
                   Object {
                     "data": Object {
                       "additional_information": "",
+                      "course_runs": Array [
+                        Object {
+                          "content_language": "en-us",
+                          "draft": undefined,
+                          "end": "2019-08-14T00:00:00Z",
+                          "expected_program_name": "Test Program Name",
+                          "expected_program_type": "micromasters",
+                          "go_live_date": "2019-05-06T00:00:00Z",
+                          "has_ofac_restrictions": false,
+                          "key": "edX101+DemoX+T2",
+                          "marketing_url": null,
+                          "max_effort": 123,
+                          "min_effort": 10,
+                          "ofac_comment": "",
+                          "pacing_type": "instructor_paced",
+                          "staff": Array [],
+                          "start": "2019-05-14T00:00:00Z",
+                          "status": "unpublished",
+                          "transcript_languages": Array [
+                            "en-us",
+                          ],
+                          "weeks_to_complete": 100,
+                        },
+                        Object {
+                          "content_language": "en-us",
+                          "draft": undefined,
+                          "end": "2019-08-14T00:00:00Z",
+                          "expected_program_name": "",
+                          "expected_program_type": null,
+                          "go_live_date": "2019-05-06T00:00:00Z",
+                          "has_ofac_restrictions": false,
+                          "key": "edX101+DemoX+T1",
+                          "marketing_url": null,
+                          "max_effort": 123,
+                          "min_effort": 10,
+                          "ofac_comment": "",
+                          "pacing_type": "instructor_paced",
+                          "staff": Array [],
+                          "start": "2019-05-14T00:00:00Z",
+                          "status": "published",
+                          "transcript_languages": Array [
+                            "en-us",
+                          ],
+                          "weeks_to_complete": 100,
+                        },
+                      ],
                       "entitlements": Array [
                         Object {
                           "currency": "USD",
@@ -7390,7 +9849,59 @@ ShallowWrapper {
                     "isFetching": false,
                   }
                 }
-                courseStatuses={Array []}
+                courseRuns={
+                  Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ]
+                }
+                courseStatuses={
+                  Array [
+                    "published",
+                  ]
+                }
                 courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={
@@ -7414,7 +9925,52 @@ ShallowWrapper {
                 initialValues={
                   Object {
                     "additional_information": "",
-                    "course_runs": undefined,
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": "123",
+                        "min_effort": "10",
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": "100",
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": "123",
+                        "min_effort": "10",
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": "100",
+                      },
+                    ],
                     "faq": "",
                     "full_description": "<p>long desc</p>",
                     "imageSrc": "http://path/to/image/woo.small",
@@ -7522,10 +10078,56 @@ ShallowWrapper {
                 "courseEditors": Object {
                   "data": Array [],
                 },
-                "courseInReview": undefined,
+                "courseInReview": false,
                 "courseInfo": Object {
                   "data": Object {
                     "additional_information": "",
+                    "course_runs": Array [
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "Test Program Name",
+                        "expected_program_type": "micromasters",
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T2",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "unpublished",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                      Object {
+                        "content_language": "en-us",
+                        "draft": undefined,
+                        "end": "2019-08-14T00:00:00Z",
+                        "expected_program_name": "",
+                        "expected_program_type": null,
+                        "go_live_date": "2019-05-06T00:00:00Z",
+                        "has_ofac_restrictions": false,
+                        "key": "edX101+DemoX+T1",
+                        "marketing_url": null,
+                        "max_effort": 123,
+                        "min_effort": 10,
+                        "ofac_comment": "",
+                        "pacing_type": "instructor_paced",
+                        "staff": Array [],
+                        "start": "2019-05-14T00:00:00Z",
+                        "status": "published",
+                        "transcript_languages": Array [
+                          "en-us",
+                        ],
+                        "weeks_to_complete": 100,
+                      },
+                    ],
                     "entitlements": Array [
                       Object {
                         "currency": "USD",
@@ -7697,8 +10299,55 @@ ShallowWrapper {
                   "error": null,
                   "isFetching": false,
                 },
-                "courseRuns": undefined,
-                "courseStatuses": Array [],
+                "courseRuns": Array [
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "Test Program Name",
+                    "expected_program_type": "micromasters",
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T2",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "unpublished",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                  Object {
+                    "content_language": "en-us",
+                    "draft": undefined,
+                    "end": "2019-08-14T00:00:00Z",
+                    "expected_program_name": "",
+                    "expected_program_type": null,
+                    "go_live_date": "2019-05-06T00:00:00Z",
+                    "has_ofac_restrictions": false,
+                    "key": "edX101+DemoX+T1",
+                    "marketing_url": null,
+                    "max_effort": "123",
+                    "min_effort": "10",
+                    "ofac_comment": "",
+                    "pacing_type": "instructor_paced",
+                    "staff": Array [],
+                    "start": "2019-05-14T00:00:00Z",
+                    "status": "published",
+                    "transcript_languages": Array [
+                      "en-us",
+                    ],
+                    "weeks_to_complete": "100",
+                  },
+                ],
+                "courseStatuses": Array [
+                  "published",
+                ],
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
@@ -7721,7 +10370,52 @@ ShallowWrapper {
                 "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                 "initialValues": Object {
                   "additional_information": "",
-                  "course_runs": undefined,
+                  "course_runs": Array [
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "Test Program Name",
+                      "expected_program_type": "micromasters",
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T2",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "unpublished",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                    Object {
+                      "content_language": "en-us",
+                      "draft": undefined,
+                      "end": "2019-08-14T00:00:00Z",
+                      "expected_program_name": "",
+                      "expected_program_type": null,
+                      "go_live_date": "2019-05-06T00:00:00Z",
+                      "has_ofac_restrictions": false,
+                      "key": "edX101+DemoX+T1",
+                      "marketing_url": null,
+                      "max_effort": "123",
+                      "min_effort": "10",
+                      "ofac_comment": "",
+                      "pacing_type": "instructor_paced",
+                      "staff": Array [],
+                      "start": "2019-05-14T00:00:00Z",
+                      "status": "published",
+                      "transcript_languages": Array [
+                        "en-us",
+                      ],
+                      "weeks_to_complete": "100",
+                    },
+                  ],
                   "faq": "",
                   "full_description": "<p>long desc</p>",
                   "imageSrc": "http://path/to/image/woo.small",

--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -194,14 +194,11 @@ function handleCourseRuns(dispatch, courseRunData, course, submitReview) {
   // make course copy so we are not re-assigning properties of this functions original params
   const newCourse = Object.assign({}, course);
   DiscoveryDataApiService[functionCall](courseRunData).then((runResponse) => {
-    if (internalReview) {
-      // replace only one run here because only one was updated via API
-      const i = newCourse.course_runs.findIndex(run => run.key === courseRunData.key);
-      newCourse.course_runs[i] = runResponse.data;
-    } else {
-      // replace all runs here because we updated multiple runs via API
-      newCourse.course_runs = runResponse.map(courseRun => courseRun.data);
-    }
+    // replace any runs that changed here because we updated the runs via API
+    runResponse.forEach((response) => {
+      const i = newCourse.course_runs.findIndex(run => run.key === response.data.key);
+      newCourse.course_runs[i] = response.data;
+    });
     dispatch(editCourseSuccess(newCourse));
     if (submitReview) dispatch(courseSubmittingSuccess());
   }).catch((error) => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,6 +10,7 @@ const getDateWithSlashes = date => (date ? moment.utc(date).format('YYYY/MM/DD')
 const getTimeString = date => (date ? moment.utc(date).format('HH:mm') : '');
 const localTimeZone = moment.tz(moment.tz.guess()).zoneAbbr();
 const formatDate = date => (date ? moment.utc(date).format('MMM DD, YYYY') : '');
+const courseRunIsArchived = run => run.status === 'unpublished' && moment().isAfter(run.end);
 
 const isSafari = /constructor/i.test(window.HTMLElement) ||
   (p => (p.toString() === '[object SafariRemoteNotification]'))(!window['safari'] || /* eslint dot-notation: 0 */
@@ -153,6 +154,7 @@ const isPristine = (initialValues, currentFormValues, runKey) => {
 };
 
 export {
+  courseRunIsArchived,
   getDateWithDashes,
   getDateWithSlashes,
   getTimeString,


### PR DESCRIPTION
To prevent load on discovery, help with requests/min, and help avoid
deadlock. This will look for course runs that were changed
as well as saving non-archived course runs if the course mode or price
changed.