### PR TITLE
Prefer key_for_reruns as course number

### DIFF
--- a/src/components/CourseTable/__snapshots__/CourseTable.test.jsx.snap
+++ b/src/components/CourseTable/__snapshots__/CourseTable.test.jsx.snap
@@ -100,7 +100,7 @@ ShallowWrapper {
                 },
                 Object {
                   "columnSortable": true,
-                  "key": "key",
+                  "key": "number",
                   "label": "Course Number",
                 },
                 Object {
@@ -207,7 +207,7 @@ ShallowWrapper {
                   },
                   Object {
                     "columnSortable": true,
-                    "key": "key",
+                    "key": "number",
                     "label": "Course Number",
                   },
                   Object {
@@ -415,7 +415,7 @@ ShallowWrapper {
                 },
                 Object {
                   "columnSortable": true,
-                  "key": "key",
+                  "key": "number",
                   "label": "Course Number",
                 },
                 Object {
@@ -519,7 +519,7 @@ ShallowWrapper {
                   },
                   Object {
                     "columnSortable": true,
-                    "key": "key",
+                    "key": "number",
                     "label": "Course Number",
                   },
                   Object {
@@ -626,7 +626,7 @@ ShallowWrapper {
                     },
                     Object {
                       "columnSortable": true,
-                      "key": "key",
+                      "key": "number",
                       "label": "Course Number",
                     },
                     Object {
@@ -834,7 +834,7 @@ ShallowWrapper {
                   },
                   Object {
                     "columnSortable": true,
-                    "key": "key",
+                    "key": "number",
                     "label": "Course Number",
                   },
                   Object {
@@ -986,7 +986,7 @@ ShallowWrapper {
                 },
                 Object {
                   "columnSortable": true,
-                  "key": "key",
+                  "key": "number",
                   "label": "Course Number",
                 },
                 Object {
@@ -1093,7 +1093,7 @@ ShallowWrapper {
                   },
                   Object {
                     "columnSortable": true,
-                    "key": "key",
+                    "key": "number",
                     "label": "Course Number",
                   },
                   Object {
@@ -1301,7 +1301,7 @@ ShallowWrapper {
                 },
                 Object {
                   "columnSortable": true,
-                  "key": "key",
+                  "key": "number",
                   "label": "Course Number",
                 },
                 Object {
@@ -1405,7 +1405,7 @@ ShallowWrapper {
                   },
                   Object {
                     "columnSortable": true,
-                    "key": "key",
+                    "key": "number",
                     "label": "Course Number",
                   },
                   Object {
@@ -1512,7 +1512,7 @@ ShallowWrapper {
                     },
                     Object {
                       "columnSortable": true,
-                      "key": "key",
+                      "key": "number",
                       "label": "Course Number",
                     },
                     Object {
@@ -1720,7 +1720,7 @@ ShallowWrapper {
                   },
                   Object {
                     "columnSortable": true,
-                    "key": "key",
+                    "key": "number",
                     "label": "Course Number",
                   },
                   Object {

--- a/src/components/CourseTable/index.jsx
+++ b/src/components/CourseTable/index.jsx
@@ -47,7 +47,7 @@ class CourseTable extends React.Component {
       },
       {
         label: 'Course Number',
-        key: 'key',
+        key: 'number',
         columnSortable: true,
       },
       {
@@ -64,6 +64,7 @@ class CourseTable extends React.Component {
       title: (<Link to={`/courses/${course.uuid}`}>{course.title}</Link>),
       owners: course.owners ? course.owners.map(owners => owners.name).join(', ') : '',
       modified: moment.utc(course.modified).format('MMM DD, YYYY'),
+      number: course.key_for_reruns || course.key,
     }));
     const showDashboard = this.isOrgWhitelisted() || administrator;
     const oldPublisherLink = `${process.env.DISCOVERY_API_BASE_URL}/publisher/`;

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -396,6 +396,7 @@ class EditCoursePage extends React.Component {
         data: {
           title,
           key,
+          key_for_reruns,
           entitlements,
           course_runs,
           uuid,
@@ -437,7 +438,8 @@ class EditCoursePage extends React.Component {
       courseStatuses.push(UNPUBLISHED);
     }
 
-    const number = key && getCourseNumber(key);
+    const numberKey = key_for_reruns || key;
+    const number = numberKey && getCourseNumber(numberKey);
     const entitlement = entitlements && entitlements[0];
 
     const errorArray = [];

--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -21,6 +21,7 @@ class DiscoveryDataApiService {
     const fields = [
       'uuid',
       'key',
+      'key_for_reruns',
       'title',
       'modified',
       'owners',


### PR DESCRIPTION
Whenever we show the course number, prefer key_for_reruns, as that is what the course team member is going to be thinking of as their key.

This doesn't change how we use course keys, just how we display them.

https://openedx.atlassian.net/browse/DISCO-1358