### PR TITLE
Avoid calling forEach on an object

### DIFF
--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -619,6 +619,7 @@ describe('EditCoursePage', () => {
         expectedSendCourse,
         [],
         false,
+        false,
       );
     });
 
@@ -647,6 +648,7 @@ describe('EditCoursePage', () => {
         expectedSendCourse,
         expectedSendCourseRuns,
         false,
+        false,
       );
     });
 
@@ -672,6 +674,7 @@ describe('EditCoursePage', () => {
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
         [expectedSendCourseRuns[1]],
+        false,
         false,
       );
     });
@@ -702,6 +705,7 @@ describe('EditCoursePage', () => {
         expectedSendCourse,
         [expectedSendCourseRuns[1]],
         true,
+        false,
       );
     });
 
@@ -730,6 +734,7 @@ describe('EditCoursePage', () => {
         expectedSendCourse,
         [expectedSendCourseRuns[0]],
         true,
+        false,
       );
     });
 
@@ -760,6 +765,7 @@ describe('EditCoursePage', () => {
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
         [expectedSendCourseRuns[1]],
+        false,
         false,
       );
     });

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -260,7 +260,7 @@ class EditCoursePage extends React.Component {
       this.prepareSendCourseRunData(courseData);
     // Process courseData to reduced data set
     const courseEditData = this.prepareSendCourseData(courseData, modifiedCourseRuns);
-    return editCourse(courseEditData, modifiedCourseRuns, !!targetRun);
+    return editCourse(courseEditData, modifiedCourseRuns, !!targetRun, !!isInternalReview);
   }
 
   displayReviewStatusAlert(status) {


### PR DESCRIPTION
This will avoid an unnecessary error when PCs and Legal submit internal reviews.