### PR TITLE
DISCO-1431: Uses raw encoding for fields in TinyMCE

### DIFF
--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -53,6 +53,7 @@ ShallowWrapper {
             init={
               Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -102,6 +103,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -130,6 +132,7 @@ ShallowWrapper {
               "disabled": false,
               "init": Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -187,6 +190,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -236,6 +240,7 @@ ShallowWrapper {
                 init={
                   Object {
                     "branding": false,
+                    "entity_encoding": "raw",
                     "menubar": false,
                     "plugins": "legacyoutput link lists",
                     "statusbar": false,
@@ -264,6 +269,7 @@ ShallowWrapper {
                 "disabled": false,
                 "init": Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -384,6 +390,7 @@ ShallowWrapper {
             init={
               Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -445,6 +452,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -473,6 +481,7 @@ ShallowWrapper {
               "disabled": false,
               "init": Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -532,6 +541,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -593,6 +603,7 @@ ShallowWrapper {
                 init={
                   Object {
                     "branding": false,
+                    "entity_encoding": "raw",
                     "menubar": false,
                     "plugins": "legacyoutput link lists",
                     "statusbar": false,
@@ -621,6 +632,7 @@ ShallowWrapper {
                 "disabled": false,
                 "init": Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -735,6 +747,7 @@ ShallowWrapper {
             init={
               Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -784,6 +797,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -812,6 +826,7 @@ ShallowWrapper {
               "disabled": false,
               "init": Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -869,6 +884,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -918,6 +934,7 @@ ShallowWrapper {
                 init={
                   Object {
                     "branding": false,
+                    "entity_encoding": "raw",
                     "menubar": false,
                     "plugins": "legacyoutput link lists",
                     "statusbar": false,
@@ -946,6 +963,7 @@ ShallowWrapper {
                 "disabled": false,
                 "init": Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -1066,6 +1084,7 @@ ShallowWrapper {
             init={
               Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -1123,6 +1142,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -1148,6 +1168,7 @@ ShallowWrapper {
               "disabled": false,
               "init": Object {
                 "branding": false,
+                "entity_encoding": "raw",
                 "menubar": false,
                 "plugins": "legacyoutput link lists",
                 "statusbar": false,
@@ -1195,6 +1216,7 @@ ShallowWrapper {
               init={
                 Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,
@@ -1252,6 +1274,7 @@ ShallowWrapper {
                 init={
                   Object {
                     "branding": false,
+                    "entity_encoding": "raw",
                     "menubar": false,
                     "plugins": "legacyoutput link lists",
                     "statusbar": false,
@@ -1277,6 +1300,7 @@ ShallowWrapper {
                 "disabled": false,
                 "init": Object {
                   "branding": false,
+                  "entity_encoding": "raw",
                   "menubar": false,
                   "plugins": "legacyoutput link lists",
                   "statusbar": false,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -82,6 +82,7 @@ class RichEditor extends React.Component {
               plugins: 'legacyoutput link lists',
               statusbar: false,
               toolbar: 'undo redo | bold italic underline | bullist numlist | link',
+              entity_encoding: 'raw',
             }}
             onChange={this.updateCharCount}
             onKeyUp={this.updateCharCount}


### PR DESCRIPTION
Diacritic characters get represented as html entities without this set, so setting this allows our backend to receive them as is and thus won't break in our `clean_html` method.