### PR TITLE
Add a special 504 message on reruns

### DIFF
--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
@@ -3337,7 +3337,7 @@ ShallowWrapper {
             />
             <StatusAlert
               alertType="danger"
-              className=""
+              className="mt-3"
               dismissible={false}
               iconClassNames={Array []}
               id="create-error"
@@ -3397,7 +3397,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className=""
+                className="mt-3"
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
@@ -3445,7 +3445,7 @@ ShallowWrapper {
                 />,
                 <StatusAlert
                   alertType="danger"
-                  className=""
+                  className="mt-3"
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
@@ -3493,7 +3493,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "danger",
-                  "className": "",
+                  "className": "mt-3",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-error",
@@ -3554,7 +3554,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className=""
+                className="mt-3"
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
@@ -3614,7 +3614,7 @@ ShallowWrapper {
                 />
                 <StatusAlert
                   alertType="danger"
-                  className=""
+                  className="mt-3"
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
@@ -3662,7 +3662,7 @@ ShallowWrapper {
                   />,
                   <StatusAlert
                     alertType="danger"
-                    className=""
+                    className="mt-3"
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-error"
@@ -3710,7 +3710,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "danger",
-                    "className": "",
+                    "className": "mt-3",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-error",

--- a/src/components/CreateCourseRunPage/index.jsx
+++ b/src/components/CreateCourseRunPage/index.jsx
@@ -179,6 +179,7 @@ class CreateCourseRunPage extends React.Component {
                 <StatusAlert
                   id="create-error"
                   alertType="danger"
+                  className="mt-3"
                   message={errorArray}
                 />
               ) }

--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -154,7 +154,15 @@ function createCourseRun(courseUuid, courseRunData) {
         return dispatch(push(`/courses/${courseUuid}`));
       })
       .catch((error) => {
-        dispatch(createCourseRunFail(['Course Run create failed, please try again or contact support.'].concat(getErrorMessages(error))));
+        let errorList;
+        if (error.response && error.response.status === 504) {
+          // See DISCO-1548. Basically, a course is so large that nginx kills requests before Studio
+          // can finish copying content. So we add a custom message about this case.
+          errorList = ['Due to the quantity of content in this course, we anticipate a longer wait time for the creation of a new course run in Publisher. The run is now available in Studio in the meantime. Please check back in a business day or contact your Project Coordinator for help.'];
+        } else {
+          errorList = ['Course Run create failed, please try again or contact support.'].concat(getErrorMessages(error));
+        }
+        dispatch(createCourseRunFail(errorList));
       });
   };
 }


### PR DESCRIPTION
As a stop-gap measure, we give a special message when receiving a 504 message back from Discovery when making a rerun.

I didn't add a test, because we still don't seem to have a good way to test network interactions. Seems bad, yah?

https://openedx.atlassian.net/browse/DISCO-1548

![Screenshot from 2020-01-24 15-00-02](https://user-images.githubusercontent.com/1196901/73099793-3ad38000-3eba-11ea-9de4-91c7862ca69b.png)
