### PR TITLE
Handle the Empty course/run type better

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -376,7 +376,7 @@ class CollapsibleCourseRun extends React.Component {
         <Field
           name={`${courseId}.run_type`}
           component={RenderSelectField}
-          options={runType ? runTypeOptions : [{ label: 'Select Course enrollment track first', value: '' }]}
+          options={runTypeOptions || [{ label: 'Select Course enrollment track first', value: '' }]}
           extraInput={{ onInvalid: this.openCollapsible }}
           label={
             <FieldLabel

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -189,7 +189,7 @@ export class BaseEditCourseForm extends React.Component {
     } = parsedTypeOptions;
 
     const disabled = courseInReview || !editable;
-    const showMarketingFields = !currentFormValues.type ||
+    const showMarketingFields = !currentFormValues.type || !courseTypes[currentFormValues.type] ||
       courseTypes[currentFormValues.type].course_run_types.some(crt => crt.is_marketable);
 
     let submitState = 'default';


### PR DESCRIPTION
Instead of showing a white page because of a JS exception, simply treat it as an unset type. Which also allows the user to change it.

https://openedx.atlassian.net/browse/DISCO-1581