### PR TITLE
Fix a typo in the previous commit

### DIFF
--- a/src/components/CourseTable/index.jsx
+++ b/src/components/CourseTable/index.jsx
@@ -93,9 +93,9 @@ class CourseTable extends React.Component {
       group.label === 'Course Editors'
     )).options.filter(option => editorsFromQuery.includes(option.value.toString())) : [];
 
-    if (courseRunStatusesFromQuery) {
+    if (!courseRunStatusesFromQuery) {
       this.setState({
-        selectedFilters: [selectedEditors],
+        selectedFilters: selectedEditors,
       });
     } else {
       this.setState(prevState => ({


### PR DESCRIPTION
It reversed a conditional, which made the dashboard filtering on course statuses behave oddly.  Whoops.