### PR TITLE
Don't ignore babel-loader in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,5 @@
     "schedule:earlyMondays"
   ],
   "statusCheckVerify": true,
-  "ignoreDeps": [
-    "babel-loader"
-  ],
   "rebaseStalePrs": true
 }


### PR DESCRIPTION
That was an old config we can drop now.