### PR TITLE
Re-publish runs by default on Save

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
@@ -228,7 +228,7 @@ describe('Collapsible Course Run', () => {
     />);
 
     const mockDispatch = jest.spyOn(store, 'dispatch');
-    component.find('ActionButton').simulate('click');
+    component.find('CourseRunButtonToolbar').simulate('submit');
     expect(mockDispatch).toHaveBeenCalledWith(courseSubmitRun(unpublishedCourseRun));
   });
 });

--- a/src/components/EditCoursePage/CourseButtonToolbar.jsx
+++ b/src/components/EditCoursePage/CourseButtonToolbar.jsx
@@ -1,0 +1,82 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import ActionButton from '../ActionButton';
+import ButtonToolbar from '../ButtonToolbar';
+
+function CourseButtonToolbar(props) {
+  const {
+    className,
+    disabled,
+    editable,
+    onClear,
+    onSave,
+    pristine,
+    publishedContentChanged,
+    submitting,
+  } = props;
+
+  if (!editable) {
+    return null;
+  }
+
+  let saveState = 'default';
+  if (submitting) {
+    saveState = 'pending';
+  } else if (pristine) {
+    saveState = 'complete';
+  } else if (publishedContentChanged) {
+    saveState = 'republish';
+  }
+
+  return (
+    <ButtonToolbar className={className}>
+      {!submitting && !pristine
+      && (
+        <button
+          className="btn btn-outline-primary"
+          disabled={disabled}
+          onClick={onClear}
+          type="button"
+        >
+          Clear Edits
+        </button>
+      )}
+      <ActionButton
+        disabled={disabled}
+        labels={{
+          default: 'Save & Continue Editing',
+          republish: 'Save & Re-Publish',
+          pending: 'Saving Course',
+          complete: 'Course Saved',
+        }}
+        state={saveState}
+        onClick={onSave}
+      />
+    </ButtonToolbar>
+  );
+}
+
+CourseButtonToolbar.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  editable: PropTypes.bool,
+  onClear: PropTypes.func,
+  onSave: PropTypes.func,
+  pristine: PropTypes.bool,
+  publishedContentChanged: PropTypes.bool,
+  submitting: PropTypes.bool,
+};
+
+CourseButtonToolbar.defaultProps = {
+  className: '',
+  disabled: false,
+  editable: false,
+  onClear: () => {},
+  onSave: () => {},
+  pristine: false,
+  publishedContentChanged: false,
+  submitting: false,
+};
+
+export default CourseButtonToolbar;

--- a/src/components/EditCoursePage/CourseRunButtonToolbar.jsx
+++ b/src/components/EditCoursePage/CourseRunButtonToolbar.jsx
@@ -1,0 +1,71 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import ButtonToolbar from '../ButtonToolbar';
+import CourseRunSubmitButton from './CourseRunSubmitButton';
+
+import { PUBLISHED, UNPUBLISHED } from '../../data/constants';
+
+function CourseRunButtonToolbar(props) {
+  const {
+    className,
+    disabled,
+    editable,
+    hasNonExemptChanges,
+    onSubmit,
+    pristine,
+    status,
+    submitting,
+  } = props;
+
+  if (!editable) {
+    return null;
+  }
+
+  if (status === PUBLISHED) {
+    if (pristine) {
+      return null;
+    }
+    return (
+      <div className="font-italic text-center">
+        To publish changes, click ‘Save & Re-Publish’ below.
+      </div>
+    );
+  }
+
+  return (
+    <ButtonToolbar className={className}>
+      <CourseRunSubmitButton
+        disabled={disabled}
+        hasNonExemptChanges={hasNonExemptChanges}
+        onSubmit={onSubmit}
+        status={status}
+        submitting={submitting}
+      />
+    </ButtonToolbar>
+  );
+}
+
+CourseRunButtonToolbar.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  editable: PropTypes.bool,
+  hasNonExemptChanges: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  pristine: PropTypes.bool,
+  status: PropTypes.string,
+  submitting: PropTypes.bool,
+};
+
+CourseRunButtonToolbar.defaultProps = {
+  className: '',
+  disabled: false,
+  editable: false,
+  hasNonExemptChanges: false,
+  onSubmit: () => {},
+  pristine: false,
+  status: UNPUBLISHED,
+  submitting: false,
+};
+
+export default CourseRunButtonToolbar;

--- a/src/components/EditCoursePage/CourseRunButtonToolbar.test.jsx
+++ b/src/components/EditCoursePage/CourseRunButtonToolbar.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+
+import CourseRunButtonToolbar from './CourseRunButtonToolbar';
+import { PUBLISHED } from '../../data/constants';
+
+describe('Course Run Button Toolbar', () => {
+  it('default parameters', () => {
+    const component = shallow(<CourseRunButtonToolbar />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('editable', () => {
+    const component = shallow(<CourseRunButtonToolbar editable />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('published pristine', () => {
+    const component = shallow(<CourseRunButtonToolbar editable pristine status={PUBLISHED} />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('published with changes', () => {
+    const component = shallow(<CourseRunButtonToolbar editable status={PUBLISHED} />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+});

--- a/src/components/EditCoursePage/CourseRunSubmitButton.jsx
+++ b/src/components/EditCoursePage/CourseRunSubmitButton.jsx
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+import ActionButton from '../ActionButton';
+
+import {
+  REVIEW_BY_INTERNAL, REVIEW_BY_LEGAL, REVIEWED, UNPUBLISHED,
+} from '../../data/constants';
+
+class CourseRunSubmitButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.submitLabel = this.submitLabel.bind(this);
+  }
+
+  submitLabel() {
+    const {
+      hasNonExemptChanges,
+      status,
+    } = this.props;
+    const { administrator } = getAuthenticatedUser();
+
+    if (administrator) {
+      switch (status) {
+        case REVIEW_BY_LEGAL:
+          return 'Save & Send to PC Review';
+        case REVIEW_BY_INTERNAL:
+          return 'PC Review Complete';
+        default:
+          break;
+      }
+    }
+    if (status === REVIEWED) {
+      if (hasNonExemptChanges) {
+        return 'Re-Submit Run for Review';
+      }
+      return 'Update Run';
+    }
+    return 'Submit Run for Review';
+  }
+
+  render() {
+    const {
+      disabled,
+      onSubmit,
+      submitting,
+    } = this.props;
+
+    return (
+      <ActionButton
+        disabled={disabled}
+        onClick={onSubmit}
+        labels={{
+          default: this.submitLabel(),
+          pending: 'Submitting Run for Review',
+        }}
+        state={submitting ? 'pending' : 'default'}
+      />
+    );
+  }
+}
+
+CourseRunSubmitButton.propTypes = {
+  disabled: PropTypes.bool,
+  hasNonExemptChanges: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  status: PropTypes.string,
+  submitting: PropTypes.bool,
+};
+
+CourseRunSubmitButton.defaultProps = {
+  disabled: false,
+  hasNonExemptChanges: false,
+  onSubmit: () => {},
+  status: UNPUBLISHED,
+  submitting: false,
+};
+
+export default CourseRunSubmitButton;

--- a/src/components/EditCoursePage/CourseRunSubmitButton.test.jsx
+++ b/src/components/EditCoursePage/CourseRunSubmitButton.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+import CourseRunSubmitButton from './CourseRunSubmitButton';
+import { REVIEW_BY_INTERNAL, REVIEW_BY_LEGAL, REVIEWED } from '../../data/constants';
+
+describe('Course Run Submit Button', () => {
+  beforeEach(() => {
+    getAuthenticatedUser.mockReturnValue({ administrator: false });
+  });
+
+  it('default parameters', () => {
+    const component = shallow(<CourseRunSubmitButton />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('disabled', () => {
+    const component = shallow(<CourseRunSubmitButton disabled />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('submitting', () => {
+    const component = shallow(<CourseRunSubmitButton submitting />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('reviewed with exempt changes', () => {
+    const component = shallow(<CourseRunSubmitButton status={REVIEWED} />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('reviewed without exempt changes', () => {
+    const component = shallow(<CourseRunSubmitButton status={REVIEWED} hasNonExemptChanges />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('legal review', () => {
+    getAuthenticatedUser.mockReturnValue({ administrator: true });
+    const component = shallow(<CourseRunSubmitButton status={REVIEW_BY_LEGAL} />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('internal review', () => {
+    getAuthenticatedUser.mockReturnValue({ administrator: true });
+    const component = shallow(<CourseRunSubmitButton status={REVIEW_BY_INTERNAL} />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+});

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -377,7 +377,7 @@ describe('EditCoursePage', () => {
       },
       {
         content_language: 'en-us',
-        draft: true,
+        draft: false,
         expected_program_type: null,
         expected_program_name: '',
         external_key: '',
@@ -412,11 +412,11 @@ describe('EditCoursePage', () => {
       expectedSendCourseRuns[0].prices = {
         verified: defaultPrice,
       };
-      expectedSendCourseRuns[1].draft = true;
+      expectedSendCourseRuns[1].draft = false;
       expectedSendCourseRuns[1].prices = {
         verified: defaultPrice,
       };
-      expectedSendCourse.draft = true;
+      expectedSendCourse.draft = false;
       expectedSendCourse.prices = {
         verified: defaultPrice,
       };
@@ -714,7 +714,6 @@ describe('EditCoursePage', () => {
       component.update();
 
       expectedSendCourseRuns[1].draft = false;
-      expectedSendCourse.draft = false;
 
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -501,6 +501,16 @@ exports[`Collapsible Course Run renders correctly when given a published course 
       No
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="published"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;
 
@@ -1005,6 +1015,16 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
       No
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="unpublished"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;
 
@@ -1509,6 +1529,16 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
       No
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="unpublished"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;
 
@@ -2013,6 +2043,16 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
       No
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="published"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;
 
@@ -2529,6 +2569,16 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
       No
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="unpublished"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;
 
@@ -3072,6 +3122,16 @@ exports[`Collapsible Course Run renders correctly with external key field enable
       No
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="unpublished"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;
 
@@ -3552,5 +3612,15 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
       --
     </div>
   </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={false}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="unpublished"
+    submitting={false}
+  />
 </CustomCollapsible>
 `;

--- a/src/components/EditCoursePage/__snapshots__/CourseRunButtonToolbar.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CourseRunButtonToolbar.test.jsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Course Run Button Toolbar default parameters 1`] = `""`;
+
+exports[`Course Run Button Toolbar editable 1`] = `
+<ButtonToolbar
+  className=""
+  leftJustify={false}
+>
+  <CourseRunSubmitButton
+    disabled={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    status="unpublished"
+    submitting={false}
+  />
+</ButtonToolbar>
+`;
+
+exports[`Course Run Button Toolbar published pristine 1`] = `""`;
+
+exports[`Course Run Button Toolbar published with changes 1`] = `
+<div
+  className="font-italic text-center"
+>
+  To publish changes, click ‘Save & Re-Publish’ below.
+</div>
+`;

--- a/src/components/EditCoursePage/__snapshots__/CourseRunSubmitButton.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CourseRunSubmitButton.test.jsx.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Course Run Submit Button default parameters 1`] = `
+<ActionButton
+  className=""
+  disabled={false}
+  labels={
+    Object {
+      "default": "Submit Run for Review",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="default"
+/>
+`;
+
+exports[`Course Run Submit Button disabled 1`] = `
+<ActionButton
+  className=""
+  disabled={true}
+  labels={
+    Object {
+      "default": "Submit Run for Review",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="default"
+/>
+`;
+
+exports[`Course Run Submit Button internal review 1`] = `
+<ActionButton
+  className=""
+  disabled={false}
+  labels={
+    Object {
+      "default": "PC Review Complete",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="default"
+/>
+`;
+
+exports[`Course Run Submit Button legal review 1`] = `
+<ActionButton
+  className=""
+  disabled={false}
+  labels={
+    Object {
+      "default": "Save & Send to PC Review",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="default"
+/>
+`;
+
+exports[`Course Run Submit Button reviewed with exempt changes 1`] = `
+<ActionButton
+  className=""
+  disabled={false}
+  labels={
+    Object {
+      "default": "Update Run",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="default"
+/>
+`;
+
+exports[`Course Run Submit Button reviewed without exempt changes 1`] = `
+<ActionButton
+  className=""
+  disabled={false}
+  labels={
+    Object {
+      "default": "Re-Submit Run for Review",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="default"
+/>
+`;
+
+exports[`Course Run Submit Button submitting 1`] = `
+<ActionButton
+  className=""
+  disabled={false}
+  labels={
+    Object {
+      "default": "Submit Run for Review",
+      "pending": "Submitting Run for Review",
+    }
+  }
+  onClick={[Function]}
+  primary={true}
+  state="pending"
+/>
+`;

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -1488,6 +1488,16 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       />
        Add Course Run
     </button>
+    <CourseButtonToolbar
+      className="mt-3"
+      disabled={true}
+      editable={false}
+      onClear={[Function]}
+      onSave={[Function]}
+      pristine={true}
+      publishedContentChanged={false}
+      submitting={false}
+    />
   </form>
 </div>
 `;
@@ -2999,6 +3009,16 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       />
        Add Course Run
     </button>
+    <CourseButtonToolbar
+      className="mt-3"
+      disabled={true}
+      editable={false}
+      onClear={[Function]}
+      onSave={[Function]}
+      pristine={false}
+      publishedContentChanged={false}
+      submitting={true}
+    />
   </form>
 </div>
 `;
@@ -4612,6 +4632,16 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       />
        Add Course Run
     </button>
+    <CourseButtonToolbar
+      className="mt-3"
+      disabled={true}
+      editable={false}
+      onClear={[Function]}
+      onSave={[Function]}
+      pristine={true}
+      publishedContentChanged={false}
+      submitting={false}
+    />
   </form>
 </div>
 `;
@@ -6123,6 +6153,16 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       />
        Add Course Run
     </button>
+    <CourseButtonToolbar
+      className="mt-3"
+      disabled={true}
+      editable={false}
+      onClear={[Function]}
+      onSave={[Function]}
+      pristine={true}
+      publishedContentChanged={false}
+      submitting={false}
+    />
   </form>
 </div>
 `;
@@ -7586,6 +7626,16 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       />
        Add Course Run
     </button>
+    <CourseButtonToolbar
+      className="mt-3"
+      disabled={true}
+      editable={false}
+      onClear={[Function]}
+      onSave={[Function]}
+      pristine={true}
+      publishedContentChanged={false}
+      submitting={false}
+    />
   </form>
 </div>
 `;


### PR DESCRIPTION
That is, when the Save button is pressed, if there are changes to an existing published run, we'll republish it automatically.

This also removes the button to specifically republish a single run.

Hopefully this will avoid users queuing up draft changes and not realizing they aren't published.

https://openedx.atlassian.net/browse/DISCO-1555

### Published run, no edits yet
![Screenshot from 2020-04-16 11-13-38](https://user-images.githubusercontent.com/1196901/79473767-94d47500-7fd3-11ea-82ac-0e486098e075.png)

### Published run with edits (at the course or run level)
![Screenshot from 2020-04-16 11-13-50](https://user-images.githubusercontent.com/1196901/79473797-9dc54680-7fd3-11ea-856b-51524a7bc8e5.png)

### Unpublished run with edits (same as before)
![Screenshot from 2020-04-16 11-14-46](https://user-images.githubusercontent.com/1196901/79473825-a87fdb80-7fd3-11ea-9a9e-fe54d13325e6.png)
