### PR TITLE
Downgrade tinymce to 5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23222,9 +23222,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinymce": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.3.1.tgz",
-      "integrity": "sha512-pIo0yb9oncUXjB+aA06v/hmUTbY7MU5K2qvpP0XPo3ng2sAFR4DnX1QzDKBi0nEomjNKwYs/82cyBXO1KA9HNw=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.2.2.tgz",
+      "integrity": "sha512-G1KZOxHIrokeP/rhJuvwctmeAuHDAeH8AI1ubnVcdMZtmC6mUh3SfESqFJrFWoiF143OUMC61GkVhi920pIP0A=="
     },
     "tinymce-language-selector": {
       "version": "github:edx/tinymce-language-selector#527066cf981a02d6f79c860557d12396a1ff9336",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
     "regenerator-runtime": "0.13.5",
-    "tinymce": "5.3.1",
+    "tinymce": "5.2.2",
     "tinymce-language-selector": "edx/tinymce-language-selector"
   },
   "devDependencies": {


### PR DESCRIPTION
5.3.0 breaks our usage of tinymce, and I don't have time right now to investigate what the proper fix is.