### PR TITLE
DISCO-1586: Fix tinymce-language-selector error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3395,6 +3395,11 @@
         "stylelint-scss": "^3.4.1"
       }
     },
+    "@edx/tinymce-language-selector": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/tinymce-language-selector/-/tinymce-language-selector-1.1.0.tgz",
+      "integrity": "sha512-yw+JVsq8vRMsTeSY8xjDIlV8xHh9HweZzz1AXPgMtrcS7gEAIYE0G0899ULICV/slBCWdYnTp1oDnDH9DanQ9w=="
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -23225,10 +23230,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.2.2.tgz",
       "integrity": "sha512-G1KZOxHIrokeP/rhJuvwctmeAuHDAeH8AI1ubnVcdMZtmC6mUh3SfESqFJrFWoiF143OUMC61GkVhi920pIP0A=="
-    },
-    "tinymce-language-selector": {
-      "version": "github:edx/tinymce-language-selector#527066cf981a02d6f79c860557d12396a1ff9336",
-      "from": "github:edx/tinymce-language-selector"
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@edx/frontend-component-footer-edx": "3.0.10",
     "@edx/frontend-platform": "1.5.0",
     "@edx/paragon": "7.2.1",
+    "@edx/tinymce-language-selector": "^1.1.0",
     "@fortawesome/free-solid-svg-icons": "5.13.0",
     "@fortawesome/react-fontawesome": "0.1.10",
     "@tinymce/tinymce-react": "3.6.0",
@@ -55,8 +56,7 @@
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
     "regenerator-runtime": "0.13.5",
-    "tinymce": "5.2.2",
-    "tinymce-language-selector": "edx/tinymce-language-selector"
+    "tinymce": "5.2.2"
   },
   "devDependencies": {
     "@edx/frontend-build": "5.0.5",

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -9,7 +9,7 @@ import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/themes/silver/theme';
 import 'style-loader!tinymce/skins/ui/oxide/skin.min.css'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved
-import 'tinymce-language-selector';
+import '@edx/tinymce-language-selector';
 import StatusAlert from '../StatusAlert';
 
 


### PR DESCRIPTION
Updated `tinymce-language-selector` to point to an npm package owned by edX, rather than our own repo.

(FYI: Our internal [tinymce-language-selector](https://github.com/edx/tinymce-language-selector) repo was updated to use [semantic-release](https://github.com/semantic-release/semantic-release) to release versions to [@edx/tinymce-language-selector](https://www.npmjs.com/package/@edx/tinymce-language-selector) on npm. Another `tinymce-language-selector` npm package based on our internal repo exists, however, it is not owned by our org so we cannot release new features/fixes to it.)