### PR TITLE
Cleanup webpack and jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,8 +6,4 @@ const config = createConfig('jest', {
   ],
 });
 
-config.transformIgnorePatterns = [
-  '/node_modules/(?!(tinymce-language-selector|@edx))/',
-];
-
 module.exports = config;

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -2,6 +2,6 @@ const { createConfig } = require('@edx/frontend-build');
 
 const config = createConfig('webpack-dev');
 
-config.module.rules[0].exclude = /node_modules\/(?!(query-string|split-on-first|strict-uri-encode|tinymce-language-selector|@edx))/;
+config.module.rules[0].exclude = /node_modules\/(?!(query-string|split-on-first|strict-uri-encode|@edx))/;
 
 module.exports = config;

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -2,6 +2,6 @@ const { createConfig } = require('@edx/frontend-build');
 
 const config = createConfig('webpack-prod');
 
-config.module.rules[0].exclude = /node_modules\/(?!(query-string|split-on-first|strict-uri-encode|tinymce-language-selector|@edx))/;
+config.module.rules[0].exclude = /node_modules\/(?!(query-string|split-on-first|strict-uri-encode|@edx))/;
 
 module.exports = config;


### PR DESCRIPTION
Removed `tinymce-language-selector` from webpack.dev.config.js,
webpack.prod.config.js, and jest.config.js. Ignoring this package
is now covered by the `@edx` in the webpack files.

DISCO-1586