### PR TITLE
fix: add upgrade deadline override field

### DIFF
--- a/src/components/CreateCoursePage/CreateCourseForm.jsx
+++ b/src/components/CreateCoursePage/CreateCourseForm.jsx
@@ -326,6 +326,7 @@ BaseCreateCourseForm.propTypes = {
     prices: PropTypes.shape(),
     start: PropTypes.string,
     end: PropTypes.string,
+    upgrade_deadline_override: PropTypes.string,
   }).isRequired,
   currentFormValues: PropTypes.shape({
     org: PropTypes.string,

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -288,6 +288,15 @@ class CollapsibleCourseRun extends React.Component {
                 helpText={courseDateEditHelp}
                 disabled
               />
+              <Field
+                name={`${courseId}.upgrade_deadline_override`}
+                type="date"
+                component={DateTimeField}
+                dateLabel="Upgrade deadline override date"
+                timeLabel={`Upgrade deadline override time (${localTimeZone})`}
+                helpText={courseDateEditHelp}
+                disabled={!administrator || disabled}
+              />
             </div>
           )
           // date inputs for all browsers besides safari
@@ -332,6 +341,15 @@ class CollapsibleCourseRun extends React.Component {
                 timeLabel={`End time (${localTimeZone})`}
                 helpText={courseDateEditHelp}
                 disabled
+              />
+              <Field
+                name={`${courseId}.upgrade_deadline_override`}
+                type="date"
+                component={DateTimeField}
+                dateLabel="Upgrade deadline override date"
+                timeLabel={`Upgrade deadline override time (${localTimeZone})`}
+                helpText={courseDateEditHelp}
+                disabled={!administrator || disabled}
               />
             </div>
           )}

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -23,6 +23,7 @@ const mockStore = configureStore();
 describe('EditCoursePage', () => {
   const defaultPrice = '77';
   const defaultEnd = '2019-08-14T00:00:00Z';
+  const defaultUpgradeDeadlineOverride = '2019-09-14T00:00:00Z';
 
   const courseInfo = {
     data: {
@@ -32,6 +33,7 @@ describe('EditCoursePage', () => {
           key: 'edX101+DemoX+T2',
           start: '2019-05-14T00:00:00Z',
           end: defaultEnd,
+          upgrade_deadline_override: '2019-05-10T00:00:00Z',
           expected_program_type: 'micromasters',
           expected_program_name: 'Test Program Name',
           go_live_date: '2019-05-06T00:00:00Z',
@@ -55,6 +57,7 @@ describe('EditCoursePage', () => {
           key: 'edX101+DemoX+T1',
           start: '2019-05-14T00:00:00Z',
           end: defaultEnd,
+          upgrade_deadline_override: '2019-05-10T00:00:00Z',
           expected_program_type: null,
           expected_program_name: '',
           go_live_date: '2019-05-06T00:00:00Z',
@@ -278,6 +281,7 @@ describe('EditCoursePage', () => {
       key: 'edX101+DemoX+T1',
       start: '2019-05-14T00:00:00Z',
       end: defaultEnd,
+      upgrade_deadline_override: defaultUpgradeDeadlineOverride,
       expected_program_type: null,
       expected_program_name: '',
       go_live_date: '2019-05-06T00:00:00Z',
@@ -376,6 +380,7 @@ describe('EditCoursePage', () => {
         status: UNPUBLISHED,
         transcript_languages: ['en-us'],
         weeks_to_complete: '100',
+        upgrade_deadline_override: defaultUpgradeDeadlineOverride,
       },
       {
         content_language: 'en-us',
@@ -396,6 +401,7 @@ describe('EditCoursePage', () => {
         status: PUBLISHED,
         transcript_languages: ['en-us'],
         weeks_to_complete: '100',
+        upgrade_deadline_override: defaultUpgradeDeadlineOverride,
       },
     ];
 
@@ -406,11 +412,13 @@ describe('EditCoursePage', () => {
 
       courseData.course_runs[0].end = defaultEnd;
       courseData.course_runs[0].status = UNPUBLISHED;
+      courseData.course_runs[0].upgrade_deadline_override = defaultUpgradeDeadlineOverride;
       courseData.prices = {
         verified: defaultPrice,
       };
 
       expectedSendCourseRuns[0].draft = true;
+      expectedSendCourseRuns[0].upgrade_deadline_override = defaultUpgradeDeadlineOverride;
       expectedSendCourseRuns[0].prices = {
         verified: defaultPrice,
       };
@@ -575,7 +583,7 @@ describe('EditCoursePage', () => {
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
-        [],
+        expectedSendCourseRuns,
         false,
         false,
         component.instance().getData,
@@ -635,12 +643,13 @@ describe('EditCoursePage', () => {
 
       courseData.prices.verified = '500.00';
       expectedSendCourse.prices.verified = '500';
+      expectedSendCourseRuns[0].prices = expectedSendCourse.prices;
       expectedSendCourseRuns[1].prices = expectedSendCourse.prices;
 
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
-        [expectedSendCourseRuns[1]],
+        expectedSendCourseRuns,
         false,
         false,
         component.instance().getData,
@@ -720,7 +729,7 @@ describe('EditCoursePage', () => {
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
-        [expectedSendCourseRuns[1]],
+        expectedSendCourseRuns,
         true,
         false,
         component.instance().getData,
@@ -752,7 +761,7 @@ describe('EditCoursePage', () => {
       component.instance().handleCourseSubmit(courseData);
       expect(mockEditCourse).toHaveBeenCalledWith(
         expectedSendCourse,
-        [expectedSendCourseRuns[0]],
+        expectedSendCourseRuns,
         true,
         false,
         component.instance().getData,

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -149,6 +149,34 @@ exports[`Collapsible Course Run renders correctly when given a published course 
       timeLabel="End time (GMT)"
       type="text"
     />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
+    />
   </div>
   <hr />
   <Field
@@ -668,6 +696,34 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
       name="test-course.end"
       timeLabel="End time (GMT)"
       type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
     />
   </div>
   <hr />
@@ -1189,6 +1245,34 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
       timeLabel="End time (GMT)"
       type="text"
     />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
+    />
   </div>
   <hr />
   <Field
@@ -1709,6 +1793,34 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
       timeLabel="End time (GMT)"
       type="text"
     />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
+    />
   </div>
   <hr />
   <Field
@@ -2228,6 +2340,34 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
       name="test-course.end"
       timeLabel="End time (GMT)"
       type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
     />
   </div>
   <hr />
@@ -2760,6 +2900,34 @@ exports[`Collapsible Course Run renders correctly with external key field enable
       name="test-course.end"
       timeLabel="End time (GMT)"
       type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
     />
   </div>
   <hr />
@@ -3317,6 +3485,34 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
       name="test-course.end"
       timeLabel="End time (GMT)"
       type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/undefined#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (GMT)"
+      type="date"
     />
   </div>
   <hr />

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -287,6 +287,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                 "transcript_languages": Array [
                   "en-us",
                 ],
+                "upgrade_deadline_override": "2019-05-10T00:00:00Z",
                 "weeks_to_complete": 100,
               },
               Object {
@@ -312,6 +313,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                 "transcript_languages": Array [
                   "en-us",
                 ],
+                "upgrade_deadline_override": "2019-05-10T00:00:00Z",
                 "weeks_to_complete": 100,
               },
             ],
@@ -394,13 +396,14 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             "ofac_comment": "",
             "pacing_type": "instructor_paced",
             "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-            "seats": Array [],
+            "seats": false,
             "staff": Array [],
             "start": "2019-05-14T00:00:00Z",
             "status": "unpublished",
             "transcript_languages": Array [
               "en-us",
             ],
+            "upgrade_deadline_override": null,
             "weeks_to_complete": "100",
           },
           Object {
@@ -419,13 +422,14 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             "ofac_comment": "",
             "pacing_type": "instructor_paced",
             "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-            "seats": Array [],
+            "seats": false,
             "staff": Array [],
             "start": "2019-05-14T00:00:00Z",
             "status": "published",
             "transcript_languages": Array [
               "en-us",
             ],
+            "upgrade_deadline_override": null,
             "weeks_to_complete": "100",
           },
         ]
@@ -477,13 +481,14 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
               "ofac_comment": "",
               "pacing_type": "instructor_paced",
               "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-              "seats": Array [],
+              "seats": false,
               "staff": Array [],
               "start": "2019-05-14T00:00:00Z",
               "status": "unpublished",
               "transcript_languages": Array [
                 "en-us",
               ],
+              "upgrade_deadline_override": null,
               "weeks_to_complete": "100",
             },
             Object {
@@ -502,13 +507,14 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
               "ofac_comment": "",
               "pacing_type": "instructor_paced",
               "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-              "seats": Array [],
+              "seats": false,
               "staff": Array [],
               "start": "2019-05-14T00:00:00Z",
               "status": "published",
               "transcript_languages": Array [
                 "en-us",
               ],
+              "upgrade_deadline_override": null,
               "weeks_to_complete": "100",
             },
           ],
@@ -670,6 +676,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                 "transcript_languages": Array [
                   "en-us",
                 ],
+                "upgrade_deadline_override": "2019-05-10T00:00:00Z",
                 "weeks_to_complete": 100,
               },
               Object {
@@ -695,6 +702,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                 "transcript_languages": Array [
                   "en-us",
                 ],
+                "upgrade_deadline_override": "2019-05-10T00:00:00Z",
                 "weeks_to_complete": 100,
               },
             ],
@@ -1060,13 +1068,14 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             "ofac_comment": "",
             "pacing_type": "instructor_paced",
             "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-            "seats": Array [],
+            "seats": false,
             "staff": Array [],
             "start": "2019-05-14T00:00:00Z",
             "status": "unpublished",
             "transcript_languages": Array [
               "en-us",
             ],
+            "upgrade_deadline_override": null,
             "weeks_to_complete": "100",
           },
           Object {
@@ -1085,13 +1094,14 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             "ofac_comment": "",
             "pacing_type": "instructor_paced",
             "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-            "seats": Array [],
+            "seats": false,
             "staff": Array [],
             "start": "2019-05-14T00:00:00Z",
             "status": "published",
             "transcript_languages": Array [
               "en-us",
             ],
+            "upgrade_deadline_override": null,
             "weeks_to_complete": "100",
           },
         ]
@@ -1143,13 +1153,14 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
               "ofac_comment": "",
               "pacing_type": "instructor_paced",
               "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-              "seats": Array [],
+              "seats": false,
               "staff": Array [],
               "start": "2019-05-14T00:00:00Z",
               "status": "unpublished",
               "transcript_languages": Array [
                 "en-us",
               ],
+              "upgrade_deadline_override": null,
               "weeks_to_complete": "100",
             },
             Object {
@@ -1168,13 +1179,14 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
               "ofac_comment": "",
               "pacing_type": "instructor_paced",
               "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-              "seats": Array [],
+              "seats": false,
               "staff": Array [],
               "start": "2019-05-14T00:00:00Z",
               "status": "published",
               "transcript_languages": Array [
                 "en-us",
               ],
+              "upgrade_deadline_override": null,
               "weeks_to_complete": "100",
             },
           ],
@@ -1503,6 +1515,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                 "transcript_languages": Array [
                   "en-us",
                 ],
+                "upgrade_deadline_override": "2019-05-10T00:00:00Z",
                 "weeks_to_complete": 100,
               },
               Object {
@@ -1528,6 +1541,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                 "transcript_languages": Array [
                   "en-us",
                 ],
+                "upgrade_deadline_override": "2019-05-10T00:00:00Z",
                 "weeks_to_complete": 100,
               },
             ],
@@ -1961,13 +1975,14 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             "ofac_comment": "",
             "pacing_type": "instructor_paced",
             "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-            "seats": Array [],
+            "seats": false,
             "staff": Array [],
             "start": "2019-05-14T00:00:00Z",
             "status": "unpublished",
             "transcript_languages": Array [
               "en-us",
             ],
+            "upgrade_deadline_override": null,
             "weeks_to_complete": "100",
           },
           Object {
@@ -1986,13 +2001,14 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             "ofac_comment": "",
             "pacing_type": "instructor_paced",
             "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-            "seats": Array [],
+            "seats": false,
             "staff": Array [],
             "start": "2019-05-14T00:00:00Z",
             "status": "published",
             "transcript_languages": Array [
               "en-us",
             ],
+            "upgrade_deadline_override": null,
             "weeks_to_complete": "100",
           },
         ]
@@ -2044,13 +2060,14 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
               "ofac_comment": "",
               "pacing_type": "instructor_paced",
               "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-              "seats": Array [],
+              "seats": false,
               "staff": Array [],
               "start": "2019-05-14T00:00:00Z",
               "status": "unpublished",
               "transcript_languages": Array [
                 "en-us",
               ],
+              "upgrade_deadline_override": null,
               "weeks_to_complete": "100",
             },
             Object {
@@ -2069,13 +2086,14 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
               "ofac_comment": "",
               "pacing_type": "instructor_paced",
               "run_type": "4e260c57-24ef-46c1-9a0d-5ec3a30f6b0c",
-              "seats": Array [],
+              "seats": false,
               "staff": Array [],
               "start": "2019-05-14T00:00:00Z",
               "status": "published",
               "transcript_languages": Array [
                 "en-us",
               ],
+              "upgrade_deadline_override": null,
               "weeks_to_complete": "100",
             },
           ],

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -14,7 +14,7 @@ import {
 import { courseRunSubmitting } from '../../data/actions/courseSubmitInfo';
 import {
   IN_REVIEW_STATUS, PUBLISHED, REVIEW_BY_INTERNAL, REVIEW_BY_LEGAL, REVIEWED,
-  UNPUBLISHED,
+  UNPUBLISHED, AUDIT_TRACK,
 } from '../../data/constants';
 import store from '../../data/store';
 import ConfirmationModal from '../ConfirmationModal';
@@ -132,6 +132,8 @@ class EditCoursePage extends React.Component {
           ? courseRun.expected_program_name : '',
         external_key: courseRun.external_key ? courseRun.external_key : '',
         go_live_date: isValidDate(courseRun.go_live_date) ? courseRun.go_live_date : null,
+        upgrade_deadline_override: isValidDate(courseRun.upgrade_deadline_override)
+          ? courseRun.upgrade_deadline_override : null,
         key: courseRun.key,
         max_effort: courseRun.max_effort ? courseRun.max_effort : null,
         min_effort: courseRun.min_effort ? courseRun.min_effort : null,
@@ -312,10 +314,28 @@ class EditCoursePage extends React.Component {
       },
     } = this.props;
 
+    const getUpgradeDeadlineOverride = (seats) => {
+      const nonAuditSeat = seats.filter(seat => seat.type !== AUDIT_TRACK.key)[0];
+      return nonAuditSeat.upgrade_deadline_override;
+    };
+
+    const buildSeats = (seats) => (
+      seats.length > 0 && seats.map(seat => ({
+        bulk_sku: seat.bulk_sku,
+        credit_hours: seat.credit_hours,
+        credit_provider: seat.credit_provider,
+        currency: seat.currency,
+        price: seat.price,
+        sku: seat.sku,
+        type: seat.type,
+      }))
+    );
+
     return course_runs && course_runs.map(courseRun => ({
       key: courseRun.key,
       start: courseRun.start,
       end: courseRun.end,
+      upgrade_deadline_override: courseRun.seats.length > 0 ? getUpgradeDeadlineOverride(courseRun.seats) : null,
       expected_program_type: courseRun.expected_program_type,
       expected_program_name: courseRun.expected_program_name,
       external_key: courseRun.external_key,
@@ -333,7 +353,7 @@ class EditCoursePage extends React.Component {
       has_ofac_restrictions: courseRun.has_ofac_restrictions,
       ofac_comment: courseRun.ofac_comment,
       run_type: courseRun.run_type,
-      seats: courseRun.seats,
+      seats: buildSeats(courseRun.seats),
     }));
   }
 


### PR DESCRIPTION
- add upgrade deadline date field in course run form.
- Only staff user can edit this field.

### Form changes:
<img width="1440" alt="Screen Shot 2021-09-10 at 7 54 00 PM" src="https://user-images.githubusercontent.com/78487564/132874595-e6969ad4-1cef-4146-b8be-4fd03890610e.png">

### Other nots:
This PR is dependent on 
https://github.com/edx/course-discovery/pull/3123/

DISCO-1622